### PR TITLE
refactor: expose `Node.parser` and fix linter errors

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,3 +13,4 @@ pytest-runner>=4.2
 Cython>=3.0.11
 pluggy>=0.7.1
 mypy==1.4.1
+types-pyinstaller==6.10.0

--- a/selectolax/lexbor.pyi
+++ b/selectolax/lexbor.pyi
@@ -37,6 +37,7 @@ class LexborCSSSelector:
     def any_matches(self, query: str, node: "LexborNode") -> bool: ...
 
 class LexborNode:
+    parser: "LexborHTMLParser"
     @property
     def mem_id(self) -> int: ...
     @property

--- a/selectolax/parser.pyi
+++ b/selectolax/parser.pyi
@@ -56,6 +56,7 @@ class Selector:
         ...
 
 class Node:
+    parser: "HTMLParser"
     @property
     def attributes(self) -> dict[str, None | str]:
         """Get all attributes that belong to the current node.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,6 +87,7 @@ def test_parse_fragment_html_with_head(impl: Impl):
     assert len(nodes[0].parser.css("head")) == 1
     assert len(nodes[0].parser.css("body")) == 0
 
+
 @pytest.mark.parametrize(*_IMPL_PARAMETRIZER)
 def test_parse_fragment_html_with_body(impl: Impl):
     html = '<!DOCTYPE html><html><body><div><script src="http://"></script></div></body></html>'
@@ -102,12 +103,12 @@ def test_parse_fragment_html_with_body(impl: Impl):
 
 @pytest.mark.parametrize(*_IMPL_PARAMETRIZER)
 def test_parse_fragment_html_with_head_and_body(impl: Impl):
-    html = '<!DOCTYPE html><html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'
+    html = '<!DOCTYPE html><html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'  # noqa: E501
     nodes = impl.parse_fragment_fn(html)
     assert len(nodes) == 1
     assert nodes[0].tag == "html"
-    assert nodes[0].html == '<html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'
-    assert nodes[0].parser.html == '<!DOCTYPE html><html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'
+    assert nodes[0].html == '<html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'  # noqa: E501
+    assert nodes[0].parser.html == '<!DOCTYPE html><html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'  # noqa: E501
 
     assert len(nodes[0].parser.css("head")) == 1
     assert len(nodes[0].parser.css("body")) == 1
@@ -122,7 +123,7 @@ def test_parse_fragment_head_and_body_no_html(impl: Impl):
     assert nodes[1].tag == "body"
     assert nodes[0].html == '<head><link href="http://"></head>'
     assert nodes[1].html == '<body><div><script src="http://"></script></div></body>'
-    assert nodes[0].parser.html == '<html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'
+    assert nodes[0].parser.html == '<html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'  # noqa: E501
 
     assert len(nodes[0].parser.css("head")) == 1
     assert len(nodes[0].parser.css("body")) == 1
@@ -167,6 +168,6 @@ def test_parse_fragment_fragment(impl: Impl):
     # NOTE: Ideally the full HTML would NOT contain `<html>`, `<head>` and `<body>` in this case,
     # but this is technical limitation of the parser.
     # But as long as user serializes fragment nodes by as `Node.html`, they should be fine.
-    assert nodes[0].parser.html == '<html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'
+    assert nodes[0].parser.html == '<html><head><link href="http://"></head><body><div><script src="http://"></script></div></body></html>'  # noqa: E501
     assert len(nodes[0].parser.css("head")) == 1
     assert len(nodes[0].parser.css("body")) == 1


### PR DESCRIPTION
I've noticed that [the pipeline](https://github.com/rushter/selectolax/actions/runs/11464473492/job/31900737602) is broken after my changes, so this MR fixes it.

Also, to resolve some typing errors, I declared `Node.parser` property 