### PR TITLE
refactor: fix dependencies

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,4 +13,4 @@ pytest-runner>=4.2
 Cython>=3.0.11
 pluggy>=0.7.1
 mypy==1.4.1
-types-pyinstaller==6.10.0
+types-pyinstaller==6.10.0.20240812


### PR DESCRIPTION
@rushter Sorry for spam. The `types-pyinstaller` dependency that I've added didn't have correct version. This fixes it. This time I did a clean installation to verify it.