### PR TITLE
Switch to furo sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'numpydoc',
+    'sphinxext.opengraph',
+    'sphinx_copybutton'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -65,7 +67,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'selectolax'
-copyright = u"2018-2023, Artem Golubin"
+copyright = u"2018-2024, Artem Golubin"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -121,12 +123,16 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 # html_theme = 'default'
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    "source_repository": "https://github.com/rushter/selectolax",
+    "source_branch": "master",
+    "source_directory": "docs/",
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -141,7 +147,7 @@ html_theme = 'sphinx_rtd_theme'
 
 # The name of an image file (relative to this directory) to place at the
 # top of the sidebar.
-# html_logo = None
+html_logo = "logo.png"
 
 # The name of an image file (within the static path) to use as favicon
 # of the docs.  This file should be a Windows icon file (.ico) being

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,6 @@ flake8>=2.6.0
 tox>=2.3.1
 coverage>=4.1
 Sphinx==8.0.2
-sphinx-rtd-theme==3.0.0
 numpydoc==1.8.0
 pytest>=3.7.2
 pytest-runner>=4.2
@@ -14,3 +13,6 @@ Cython>=3.0.11
 pluggy>=0.7.1
 mypy==1.4.1
 types-pyinstaller==6.10.0.20240812
+furo==2024.8.6
+sphinxext-opengraph==0.9.1
+sphinx-copybutton==0.5.2


### PR DESCRIPTION
Hi @rushter,
I've been using selectolax for quite a while now as a fast drop-in replacement for beautifulsoup4.

I wondered if it might be possible to switch the docs theme to enhance the readability.

The [`furo`](https://pradyunsg.me/furo/) theme offers several advantages such as the inbuilt dark theme and responsive design.

A summary of my proposed changes:

* enable dark theme
* enhance SEO score by adding OpenGraph tags
* add references to git repository in docs
* add 'copy' button to code blocks
* include logo

It might also be considered to minify the generated assets to further enhance the UX by decreasing load times.