### PR TITLE
 fix: header detected as head

### DIFF
--- a/selectolax/utils.pxi
+++ b/selectolax/utils.pxi
@@ -34,7 +34,7 @@ def get_fragment_type(
         tree = parser_cls(html)
     
     import re
-    html_re = re.compile(r"<html|<body|<head", re.IGNORECASE)
+    html_re = re.compile(r"<html|<body|<head(?!er)", re.IGNORECASE)
 
     has_html = False
     has_head = False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,6 +49,12 @@ def test_create_tag(impl: Impl):
     assert node.html == "<p></p>"
 
 
+@pytest.mark.parametrize(*_IMPL_PARAMETRIZER)
+def test_create_header_tag(impl: Impl):
+    node = impl.tag_fn("header")
+    assert isinstance(node, impl.node)
+    assert node.html == "<header></header>"
+
 # Cases to test parse_fragment():
 # - <doctyle> + <html> only
 # - HTML with <head>


### PR DESCRIPTION
Fixes a regular expression that interpreted header elements as head elements

Closes #148 