### PR TITLE
Bump version: 0.3.26 → 0.3.27

### DIFF
--- a/selectolax/__init__.py
+++ b/selectolax/__init__.py
@@ -3,7 +3,7 @@
 
 __author__ = """Artem Golubin"""
 __email__ = 'me@rushter.com'
-__version__ = '0.3.26'
+__version__ = '0.3.27'
 
 from . import parser
 from . import lexbor

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.26
+current_version = 0.3.27
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ def make_extensions():
 
 setup(
     name="selectolax",
-    version='0.3.26',
+    version='0.3.27',
     description="Fast HTML5 parser with CSS selectors.",
     long_description=readme,
     author="Artem Golubin",


### PR DESCRIPTION
This might be a little cheeky of me to get the ball rolling on a new release, and I apologize if that's the case. I'm looking to use Selectolax in a website to convert regular Markdown-generated HTML into [Pico cards](https://picocss.com/docs/card#sectioning), and those use the `<header>` element