### PR TITLE
Delete `_pyinstaller/hook-selectolax.py`

### DIFF
--- a/selectolax/_pyinstaller/hook-selectolax.py
+++ b/selectolax/_pyinstaller/hook-selectolax.py
@@ -1,3 +1,0 @@
-from PyInstaller.utils.hooks import collect_data_files
-
-datas = collect_data_files("selectolax")


### PR DESCRIPTION
Hi,

This hook was contributed to `pyinstaller/pyinstaller-hooks-contrib`.

Pull Request on `pyinstaller/pyinstaller-hooks-contrib`:
- https://github.com/pyinstaller/pyinstaller-hooks-contrib/pull/841
