### PR TITLE
Fix typo at a variable declaration in lexbor html serialization

### DIFF
--- a/selectolax/lexbor/node.pxi
+++ b/selectolax/lexbor/node.pxi
@@ -95,7 +95,7 @@ cdef class LexborNode:
         text : str
         """
         cdef lexbor_str_t *lxb_str
-        cdef lxb_status_t lxb_status_t
+        cdef lxb_status_t status
 
         lxb_str = lexbor_str_create()
         status = lxb_html_serialize_tree_str(self.node, lxb_str)


### PR DESCRIPTION
#153 may be relevant with this fix.