### PR TITLE
Fixed type annotation for `css_first` methods and added type safety tests for it.

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,7 +25,10 @@ jobs:
         USE_LEXBOR=1 python setup.py build_ext --inplace --cython
     - name: Test with pytest
       run: |
-        USE_LEXBOR=1 pytest
+        USE_LEXBOR=1 pytest tests
+    - name: Test typesafety
+      run: |
+        pytest typesafety
   lint:
     strategy:
       max-parallel: 6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,3 +17,4 @@ sphinxext-opengraph==0.9.1
 sphinx-copybutton==0.5.2
 ruff
 setuptools==75.7.0
+pytest-mypy-plugins>=3.2,<4.0.0

--- a/selectolax/parser.pyi
+++ b/selectolax/parser.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Iterator, TypeVar, Literal, overload
+from typing import Iterator, TypeVar, Literal, overload
 
 DefaultT = TypeVar("DefaultT")
 
@@ -146,17 +146,13 @@ class Node:
         ...
     @overload
     def css_first(
-        self, query: str, default: Any = ..., strict: Literal[True] = ...
-    ) -> Node: ...
+            self, query: str, default: DefaultT, strict: bool = False
+    ) -> Node | DefaultT:
+        ...
     @overload
     def css_first(
-        self, query: str, default: DefaultT, strict: bool = False
-    ) -> Node | DefaultT: ...
-    @overload
-    def css_first(
-        self, query: str, default: None = ..., strict: bool = False
-    ) -> Node | None:
-        """Evaluate CSS selector against current node and its child nodes."""
+            self, query: str, default: None = None, strict: bool = False
+    ) -> Node | None | DefaultT:
         ...
     def decompose(self, recursive: bool = True) -> None:
         """Remove a Node from the tree."""
@@ -237,17 +233,14 @@ class HTMLParser:
         ...
     @overload
     def css_first(
-        self, query: str, default: Any = ..., strict: Literal[True] = ...
-    ) -> Node: ...
-    @overload
-    def css_first(
         self, query: str, default: DefaultT, strict: bool = False
-    ) -> Node | DefaultT: ...
+    ) -> Node | DefaultT:
+        ...
+
     @overload
     def css_first(
-        self, query: str, default: None = ..., strict: bool = False
-    ) -> Node | None:
-        """Same as css but returns only the first match."""
+            self, query: str, default: None = None, strict: bool = False
+    ) -> Node | None | DefaultT:
         ...
     @property
     def input_encoding(self) -> str:

--- a/typesafety/test_lexbor.yaml
+++ b/typesafety/test_lexbor.yaml
@@ -1,0 +1,66 @@
+- case: html_parser_css_first_without_default
+  parametrized:
+    - strict: True
+    - strict: False
+  main: |
+    from selectolax.parser import HTMLParser
+    parser = HTMLParser("")
+    node = parser.css_first(query="", strict= {{ strict }})
+    reveal_type(node) # N: Revealed type is "Union[selectolax.parser.Node, None]"
+
+- case: html_parser_css_first_with_none_default
+  parametrized:
+    - strict: True
+    - strict: False
+  main: |
+    from selectolax.parser import HTMLParser
+    parser = HTMLParser("")
+    node = parser.css_first(query="",default=None,strict= {{strict}})
+    reveal_type(node) # N: Revealed type is "Union[selectolax.parser.Node, None]"
+
+- case: html_parser_css_first_with_default
+  parametrized:
+    - strict: True
+    - strict: False
+  main: |
+    from selectolax.parser import HTMLParser
+    parser = HTMLParser("")
+    node = parser.css_first(query="",default="", strict ={{strict}})
+    reveal_type(node) # N: Revealed type is "Union[selectolax.parser.Node, builtins.str]"
+
+
+- case: lexbor_node_css_first_without_default
+  parametrized:
+    - strict: True
+    - strict: False
+  main: |
+    from selectolax.parser import HTMLParser
+    parser = HTMLParser("")
+    node = parser.root
+    if node is not None:
+      res = node.css_first(query="", strict ={{strict}})
+      reveal_type(res) # N: Revealed type is "Union[selectolax.parser.Node, None]"
+
+- case: lexbor_node_css_first_with_none_default
+  parametrized:
+    - strict: True
+    - strict: False
+  main: |
+    from selectolax.parser import HTMLParser
+    parser = HTMLParser("")
+    node = parser.root
+    if node is not None:
+      res = node.css_first(query="",default=None, strict ={{strict}})
+      reveal_type(res) # N: Revealed type is "Union[selectolax.parser.Node, None]"
+
+- case: lexbor_node_css_first_with_default
+  parametrized:
+    - strict: True
+    - strict: False
+  main: |
+    from selectolax.parser import HTMLParser
+    parser = HTMLParser("")
+    node = parser.root
+    if node is not None:
+      res = node.css_first(query="",default="", strict ={{strict}})
+      reveal_type(res) # N: Revealed type is "Union[selectolax.parser.Node, builtins.str]"


### PR DESCRIPTION
Hi! Thank you for supporting this project to everyone involved, I am very glad to use it!

After upgrading to the newest version of selectolax, I started getting errors from mypy when using the 'css_first` methods.

After a little research, I found https://github.com/rushter/selectolax/pull/143 and https://github.com/rushter/selectolax/pull/142 where improvements were made to the stub files. However, there are some minor mistakes that I want to fix.

Firstly, in the comment https://github.com/rushter/selectolax/pull/143#issue-2648156855 @ilotoki0804 says that when using strict=True, `None` will never be returned. Indeed, there is a little confusion with this parameter, since it is not very clear when it will throw an error and when it will not on documentation, but it is clear from the [current code](https://github.com/rushter/selectolax/blob/71614e4b615f8768ec4d232b310dd597800535f6/selectolax/lexbor/node.pxi#L216).  That it will throw an error only if it was possible to find elements, but there are more than one of them, but if no element could be found, the error will not be thrown. Therefore, this parameter has no effect on the type of the returned value.

Secondly, if I call the `css_first(query="some css query") method`without the `default` parameter, then according to the current type annotations I should get `Node`, not `Union[Node, None]`, I fixed it.

Thirdly, in order to prevent this from breaking in the future, I found a wonderful type checking tool. https://github.com/typeddjango/pytest-mypy-plugins and he wrote the tests.

I also want @ilotoki0804 to watch this mr, as I may have overlooked something.