### PR TITLE
Sort Module Imports, Reformat Code & Some Internal Refactoring

### DIFF
--- a/selectolax/__init__.py
+++ b/selectolax/__init__.py
@@ -2,9 +2,7 @@
 
 
 __author__ = """Artem Golubin"""
-__email__ = 'me@rushter.com'
-__version__ = '0.3.32'
+__email__ = "me@rushter.com"
+__version__ = "0.3.32"
 
-from . import parser
-from . import lexbor
-from . import modest
+from . import lexbor, modest, parser

--- a/selectolax/lexbor.pxd
+++ b/selectolax/lexbor.pxd
@@ -235,8 +235,10 @@ cdef class LexborNode:
     cdef:
         lxb_dom_node_t *node
         public LexborHTMLParser parser
+        
     @staticmethod
     cdef LexborNode new(lxb_dom_node_t *node, LexborHTMLParser parser)
+
 
 cdef class LexborCSSSelector:
     cdef lxb_css_parser_t* parser
@@ -244,9 +246,9 @@ cdef class LexborCSSSelector:
     cdef lxb_css_selectors_t * css_selectors
     cdef public list results
     cdef public LexborNode current_node
-    cdef _create_css_parser(self)
-    cpdef find(self, str query, LexborNode node)
-    cpdef any_matches(self, str query, LexborNode node)
+    cdef int _create_css_parser(self) except -1
+    cpdef list find(self, str query, LexborNode node)
+    cpdef int any_matches(self, str query, LexborNode node) except -1
 
 cdef class LexborHTMLParser:
     cdef lxb_html_document_t *document

--- a/selectolax/lexbor.pxd
+++ b/selectolax/lexbor.pxd
@@ -1,4 +1,4 @@
-from libc.stdint cimport uint32_t, uint8_t, uintptr_t
+from libc.stdint cimport uint8_t, uint32_t, uintptr_t
 
 
 cdef extern from "lexbor/core/core.h" nogil:
@@ -232,9 +232,11 @@ cdef extern from "lexbor/html/html.h" nogil:
     lxb_status_t lxb_html_serialize_tree_str(lxb_dom_node_t *node, lexbor_str_t *str)
 
 cdef class LexborNode:
-    cdef lxb_dom_node_t *node
-    cdef public LexborHTMLParser parser
-    cdef _cinit(self, lxb_dom_node_t *node, LexborHTMLParser parser)
+    cdef:
+        lxb_dom_node_t *node
+        public LexborHTMLParser parser
+    @staticmethod
+    cdef LexborNode new(lxb_dom_node_t *node, LexborHTMLParser parser)
 
 cdef class LexborCSSSelector:
     cdef lxb_css_parser_t* parser
@@ -250,7 +252,7 @@ cdef class LexborHTMLParser:
     cdef lxb_html_document_t *document
     cdef public bytes raw_html
     cdef LexborCSSSelector _selector
-    cdef _parse_html(self, char* html, size_t html_len)
+    cdef int _parse_html(self, char* html, size_t html_len) except -1
     cdef object cached_script_texts
     cdef object cached_script_srcs
 

--- a/selectolax/lexbor.pyi
+++ b/selectolax/lexbor.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Iterator, Literal, TypeVar, NoReturn, overload, Optional
+from typing import Any, Iterator, Literal, NoReturn, Optional, TypeVar, overload
 
 DefaultT = TypeVar("DefaultT")
 

--- a/selectolax/lexbor/node.pxi
+++ b/selectolax/lexbor/node.pxi
@@ -299,6 +299,7 @@ cdef class LexborNode:
         '<html><body><div>Hello world!</div></body></html>'
 
         """
+        cdef LexborNode element
         for tag in tags:
             for element in self.css(tag):
                 element.decompose(recursive=recursive)
@@ -751,6 +752,7 @@ cdef class LexborNode:
             The query to check.
 
         """
+        cdef LexborNode node
         if self.parser.cached_script_texts is None:
             nodes = self.parser.selector.find('script', self)
             text_nodes = []
@@ -775,6 +777,7 @@ cdef class LexborNode:
         queries : tuple of str
 
         """
+        cdef LexborNode node
         if self.parser.cached_script_srcs is None:
             nodes = self.parser.selector.find('script', self)
             src_nodes = []
@@ -830,21 +833,31 @@ cdef class LexborNode:
         """
         cdef unsigned char * text
         cdef lxb_dom_node_t* node = <lxb_dom_node_t*> self.node.first_child
-
-        container = TextContainer()
+        cdef TextContainer container
         if self.node == NULL or self.node.type != LXB_DOM_NODE_TYPE_TEXT:
             return None
+        
         text = <unsigned char *> lexbor_str_data_noi(&(<lxb_dom_character_data_t *> self.node).data)
         if text != NULL:
+            container = TextContainer.new_with_defaults()
             py_text = text.decode(_ENCODING)
             container.append(py_text)
             return container.text
 
+@cython.internal
 @cython.final
 cdef class TextContainer:
     cdef str _text
-    cdef public str separator
-    cdef public bool strip
+    cdef str separator
+    cdef bint strip
+
+    @staticmethod
+    cdef TextContainer new_with_defaults():
+        cdef TextContainer cls = TextContainer.__new__(TextContainer)
+        cls._text = ''
+        cls.separator = ''
+        cls.strip = False 
+        return cls
 
     def __init__(self, str separator = '', bool strip = False):
         self._text = ""

--- a/selectolax/lexbor/selection.pxi
+++ b/selectolax/lexbor/selection.pxi
@@ -178,8 +178,7 @@ cdef lxb_status_t css_finder_callback(lxb_dom_node_t *node, lxb_css_selector_spe
     cdef LexborNode lxb_node
     cdef object cls
     cls = <object> ctx
-    lxb_node = LexborNode()
-    lxb_node._cinit(<lxb_dom_node_t *> node, cls.current_node.parser)
+    lxb_node = LexborNode.new(<lxb_dom_node_t *> node, cls.current_node.parser)
     cls.results.append(lxb_node)
     return LXB_STATUS_OK
 

--- a/selectolax/modest/node.pxi
+++ b/selectolax/modest/node.pxi
@@ -1,4 +1,5 @@
 cimport cython
+from cpython.exc cimport PyErr_NoMemory
 
 from libc.stdlib cimport free
 from libc.stdlib cimport malloc
@@ -23,9 +24,10 @@ cdef class Stack:
     cdef bint is_empty(self):
         return self.top <= 0
 
-    cdef push(self, myhtml_tree_node_t* res):
+    cdef int push(self, myhtml_tree_node_t* res) except -1:
         if self.top >= self.capacity:
-            self.resize()
+            if self.resize() < 0:
+                return -1
         self._stack[self.top] = res
         self.top += 1
 
@@ -33,10 +35,13 @@ cdef class Stack:
         self.top = self.top - 1
         return self._stack[self.top]
 
-    cdef resize(self):
+    cdef int resize(self) except -1:
         self.capacity *= 2
         self._stack = <myhtml_tree_node_t**> realloc(<void*> self._stack, self.capacity * sizeof(myhtml_tree_node_t))
-
+        if self._stack == NULL:
+            PyErr_NoMemory()
+            return -1
+        return 0
 
 cdef class _Attributes:
     """A dict-like object that represents attributes."""
@@ -143,12 +148,13 @@ cdef class Node:
     cdef myhtml_tree_node_t *node
     cdef public HTMLParser parser
 
-
-    cdef _init(self, myhtml_tree_node_t *node, HTMLParser parser):
-        # custom init, because __cinit__ doesn't accept C types
-        self.node = node
-        # Keep reference to the selector object, so myhtml structures will not be garbage collected prematurely
-        self.parser = parser
+    @staticmethod
+    cdef Node new(myhtml_tree_node_t *node, HTMLParser parser):
+        # custom __new__ for C, because __cinit__ doesn't accept C types
+        cdef Node cls = Node.__new__(Node)
+        cls.node = node
+        cls.parser = parser
+        return cls
 
     @property
     def attributes(self):
@@ -341,8 +347,7 @@ cdef class Node:
                 node = node.next
                 continue
 
-            next_node = Node()
-            next_node._init(node, self.parser)
+            next_node = Node.new(node, self.parser)
             yield next_node
             node = node.next
 
@@ -360,16 +365,15 @@ cdef class Node:
         node
         """
         cdef Stack stack = Stack(_STACK_SIZE)
-        cdef myhtml_tree_node_t* current_node = NULL;
-        cdef Node next_node;
+        cdef myhtml_tree_node_t* current_node = NULL
+        cdef Node next_node
 
         stack.push(self.node)
 
         while not stack.is_empty():
             current_node = stack.pop()
             if current_node != NULL and not (current_node.tag_id == MyHTML_TAG__TEXT and not include_text):
-                next_node = Node()
-                next_node._init(current_node, self.parser)
+                next_node = Node.new(current_node, self.parser)
                 yield next_node
 
             if current_node.next is not NULL:
@@ -398,8 +402,7 @@ cdef class Node:
         """Return the child node."""
         cdef Node node
         if self.node.child:
-            node = Node()
-            node._init(self.node.child, self.parser)
+            node = Node.new(self.node.child, self.parser)
             return node
         return None
 
@@ -408,8 +411,7 @@ cdef class Node:
         """Return the parent node."""
         cdef Node node
         if self.node.parent:
-            node = Node()
-            node._init(self.node.parent, self.parser)
+            node = Node.new(self.node.parent, self.parser)
             return node
         return None
 
@@ -418,8 +420,7 @@ cdef class Node:
         """Return next node."""
         cdef Node node
         if self.node.next:
-            node = Node()
-            node._init(self.node.next, self.parser)
+            node = Node.new(self.node.next, self.parser)
             return node
         return None
 
@@ -428,8 +429,7 @@ cdef class Node:
         """Return previous node."""
         cdef Node node
         if self.node.prev:
-            node = Node()
-            node._init(self.node.prev, self.parser)
+            node = Node.new(self.node.prev, self.parser)
             return node
         return None
 
@@ -438,8 +438,7 @@ cdef class Node:
         """Return last child node."""
         cdef Node node
         if self.node.last_child:
-            node = Node()
-            node._init(self.node.last_child, self.parser)
+            node = Node.new(self.node.last_child, self.parser)
             return node
         return None
 
@@ -539,8 +538,8 @@ cdef class Node:
             if delete_empty:
                 myhtml_node_delete(self.node)
             return
-        cdef myhtml_tree_node_t* next_node;
-        cdef myhtml_tree_node_t* current_node;
+        cdef myhtml_tree_node_t* next_node
+        cdef myhtml_tree_node_t* current_node
 
         if self.node.child.next != NULL:
             current_node = self.node.child
@@ -574,6 +573,8 @@ cdef class Node:
         '<html><body><div>Hello world!</div></body></html>'
 
         """
+        # ensure cython can recast element to a Node so that decompose will be called sooner.
+        cdef Node element
         for tag in tags:
             for element in self.css(tag):
                 element.decompose(recursive=recursive)
@@ -600,7 +601,7 @@ cdef class Node:
 
         Note: by default, empty tags are ignored, set "delete_empty" to "True" to change this.
         """
-
+        cdef Node element
         for tag in tags:
             for element in self.css(tag):
                 element.unwrap(delete_empty)
@@ -788,7 +789,7 @@ cdef class Node:
 
         Note: by default, empty tags are ignored, set "delete_empty" to "True" to change this.
         """
-
+        cdef Node element
         for tag in tags:
             for element in self.css(tag):
                 element.unwrap(delete_empty)
@@ -847,6 +848,7 @@ cdef class Node:
             The query to check.
 
         """
+        cdef Node node
         if self.parser.cached_script_texts is None:
             nodes = find_nodes(self.parser, self.node, 'script')
             text_nodes = []

--- a/selectolax/modest/node.pxi
+++ b/selectolax/modest/node.pxi
@@ -150,9 +150,10 @@ cdef class Node:
 
     @staticmethod
     cdef Node new(myhtml_tree_node_t *node, HTMLParser parser):
-        # custom __new__ for C, because __cinit__ doesn't accept C types
+        # custom __init__ for C, because __cinit__ doesn't accept C types
         cdef Node cls = Node.__new__(Node)
         cls.node = node
+        # Keep reference to the selector object, so myhtml structures will not be garbage collected prematurely
         cls.parser = parser
         return cls
 

--- a/selectolax/modest/selection.pxi
+++ b/selectolax/modest/selection.pxi
@@ -1,4 +1,5 @@
 cimport cython
+from cpython.exc cimport PyErr_SetObject
 
 @cython.final
 cdef class CSSSelector:
@@ -29,26 +30,27 @@ cdef class CSSSelector:
         return collection
 
 
-    cdef _create_css_parser(self):
+    cdef int _create_css_parser(self) except -1:
         cdef mystatus_t status
 
         cdef mycss_t *mycss = mycss_create()
         status = mycss_init(mycss)
 
         if status != 0:
-            raise RuntimeError("Can't init MyCSS object.")
-            # return
+            PyErr_SetObject(RuntimeError, "Can't init MyCSS object.")
+            return -1
 
         self.css_entry = mycss_entry_create()
         status = mycss_entry_init(mycss, self.css_entry)
 
         if status != 0:
-            raise RuntimeError("Can't init MyCSS Entry object.")
+            PyErr_SetObject(RuntimeError, "Can't init MyCSS Entry object.")
+            return -1
+        return 0
 
 
-
-    cdef _prepare_selector(self, mycss_entry_t *css_entry,
-                                                   const char *selector, size_t selector_size):
+    cdef int _prepare_selector(self, mycss_entry_t *css_entry,
+                                                   const char *selector, size_t selector_size) except -1:
         cdef mystatus_t out_status;
         self.selectors_list = mycss_selectors_parse(mycss_entry_selectors(css_entry),
                                                          myencoding_t.MyENCODING_UTF_8,
@@ -56,7 +58,9 @@ cdef class CSSSelector:
                                                          &out_status)
 
         if (self.selectors_list == NULL) or (self.selectors_list.flags and MyCSS_SELECTORS_FLAGS_SELECTOR_BAD):
-            raise  ValueError("Bad CSS Selectors: %s" % self.c_selector.decode('utf-8'))
+            PyErr_SetObject(ValueError, "Bad CSS Selectors: %s" % self.c_selector.decode('utf-8'))
+            return -1
+        return 0
 
     def __dealloc__(self):
         mycss_selectors_list_destroy(mycss_entry_selectors(self.css_entry), self.selectors_list, 1)
@@ -77,7 +81,7 @@ cdef class Selector:
     cdef Node node
     cdef list nodes
 
-    def __init__(self, Node node, query):
+    def __init__(self, Node node, str query):
         """custom init, because __cinit__ doesn't accept C types"""
         self.node = node
         self.nodes = find_nodes(node.parser, node.node, query) if query else [node, ]
@@ -106,6 +110,7 @@ cdef class Selector:
     def text_contains(self, str text, bool deep=True, str separator='', bool strip=False):
         """Filter all current matches given text."""
         nodes = []
+        cdef Node node
         for node in self.nodes:
             node_text = node.text(deep=deep, separator=separator, strip=strip)
             if node_text and text in node_text:
@@ -116,6 +121,7 @@ cdef class Selector:
     def any_text_contains(self, str text, bool deep=True, str separator='', bool strip=False):
         """Returns True if any node in the current search scope contains specified text"""
         nodes = []
+        cdef Node node
         for node in self.nodes:
             node_text = node.text(deep=deep, separator=separator, strip=strip)
             if node_text and text in node_text:
@@ -142,7 +148,8 @@ cdef class Selector:
 
         Similar to `string-length` in XPath.
         """
-        nodes = []
+        cdef list nodes = []
+        cdef Node node
         for node in self.nodes:
             attr = node.attributes.get(attribute)
             if attr and start and start in attr:
@@ -157,16 +164,15 @@ cdef class Selector:
 cdef find_nodes(HTMLParser parser, myhtml_tree_node_t *node, str query):
     cdef myhtml_collection_t *collection
     cdef CSSSelector selector = CSSSelector(query)
-
-    result = list()
+    cdef Node n
+    cdef list result = []
     collection = selector.find(node)
 
     if collection == NULL:
         return result
 
     for i in range(collection.length):
-        n = Node()
-        n._init(collection.list[i], parser)
+        n = Node.new(collection.list[i], parser)
         result.append(n)
     myhtml_collection_destroy(collection)
     return result
@@ -176,6 +182,7 @@ cdef bool find_matches(HTMLParser parser, myhtml_tree_node_t *node, tuple select
     cdef myhtml_collection_t *collection
     cdef CSSSelector selector
     cdef int collection_size
+    cdef str query
 
     for query in selectors:
         selector = CSSSelector(query)

--- a/selectolax/parser.pxd
+++ b/selectolax/parser.pxd
@@ -562,7 +562,7 @@ cdef class HTMLParser:
     cdef object cached_script_srcs
 
     cdef void _detect_encoding(self, char* html, size_t html_len) nogil
-    cdef _parse_html(self, char* html, size_t html_len)
+    cdef int _parse_html(self, char* html, size_t html_len) except -1
     @staticmethod
     cdef HTMLParser from_tree(
         myhtml_tree_t * tree, bytes raw_html, bint detect_encoding, bint use_meta_tags, str decode_errors,
@@ -576,6 +576,6 @@ cdef class Stack:
     cdef myhtml_tree_node_t ** _stack
 
     cdef bint is_empty(self)
-    cdef push(self, myhtml_tree_node_t* res)
+    cdef int push(self, myhtml_tree_node_t* res) except -1
     cdef myhtml_tree_node_t * pop(self)
-    cdef resize(self)
+    cdef int resize(self) except -1

--- a/selectolax/parser.pyi
+++ b/selectolax/parser.pyi
@@ -1,4 +1,4 @@
-from typing import Iterator, TypeVar, Literal, overload
+from typing import Iterator, Literal, TypeVar, overload
 
 DefaultT = TypeVar("DefaultT")
 

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ def make_extensions():
 
 setup(
     name="selectolax",
-    version='0.3.32',
+    version="0.3.32",
     description="Fast HTML5 parser with CSS selectors.",
     long_description=readme,
     author="Artem Golubin",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -304,6 +304,7 @@ def test_decompose_root_node():
     with pytest.raises(SelectolaxError):
         html_parser.root.decompose()
 
+
 def test_empty_attribute_lexbor():
     div = create_tag("div")
     div.attrs["hidden"] = None


### PR DESCRIPTION
Originally my plan was to implement a C Capsule for this library for users who were planning to use this library in Cython due to it's performance benefits and mainly to make it so that users wouldn't have to compile a lot of c files together, but before I decide on implementing that I saw a handful of things that could be changed and redone. Based on my previous experiences with contributing to aiohttp I seem to have figured out ways to improve this library as well. Know that this shouldn't affect the frontend code and I was mainly interested in finding more ways to speedup the library.

I also ran isort & ruff on these modules to see if that would improve readability but if there's something you don't like please let me know.