### PR TITLE
Lexbor merge text nodes

### DIFF
--- a/selectolax/lexbor.pxd
+++ b/selectolax/lexbor.pxd
@@ -290,6 +290,8 @@ cdef extern from "lexbor/dom/dom.h" nogil:
 
     lxb_dom_collection_t * lxb_dom_collection_make(lxb_dom_document_t *document, size_t start_list_size)
     lxb_char_t * lxb_dom_node_text_content(lxb_dom_node_t *node, size_t *len)
+    lxb_status_t lxb_dom_node_text_content_set(lxb_dom_node_t *node, const lxb_char_t *content, size_t len)
+    void lxb_dom_node_remove(lxb_dom_node_t *node)
     void * lxb_dom_document_destroy_text_noi(lxb_dom_document_t *document, lxb_char_t *text)
     lxb_dom_node_t * lxb_dom_document_root(lxb_dom_document_t *document)
     lxb_char_t * lxb_dom_element_qualified_name(lxb_dom_element_t *element, size_t *len)

--- a/selectolax/lexbor.pyi
+++ b/selectolax/lexbor.pyi
@@ -384,6 +384,25 @@ class LexborNode:
         Note: by default, empty tags are ignored, use "delete_empty" to change this.
         """
         ...
+    def merge_text_nodes(self) -> None:
+        """Iterates over all text nodes and merges all text nodes that are close to each other.
+
+        This is useful for text extraction.
+        Use it when you need to strip HTML tags and merge "dangling" text.
+
+        Examples
+        --------
+
+        >>> tree = LexborHTMLParser("<div><p><strong>J</strong>ohn</p><p>Doe</p></div>")
+        >>> node = tree.css_first('div')
+        >>> tree.unwrap_tags(["strong"])
+        >>> tree.text(deep=True, separator=" ", strip=True)
+        "J ohn Doe" # Text extraction produces an extra space because the strong tag was removed.
+        >>> node.merge_text_nodes()
+        >>> tree.text(deep=True, separator=" ", strip=True)
+        "John Doe"
+        """
+        ...
     def traverse(self, include_text: bool = False) -> Iterator[LexborNode]:
         """Iterate over all child and next nodes starting from the current level.
 
@@ -779,6 +798,25 @@ class LexborHTMLParser:
         """
         ...
     def css_matches(self, selector: str) -> bool: ...
+    def merge_text_nodes(self) -> None:
+        """Iterates over all text nodes and merges all text nodes that are close to each other.
+
+        This is useful for text extraction.
+        Use it when you need to strip HTML tags and merge "dangling" text.
+
+        Examples
+        --------
+
+        >>> tree = LexborHTMLParser("<div><p><strong>J</strong>ohn</p><p>Doe</p></div>")
+        >>> node = tree.css_first('div')
+        >>> tree.unwrap_tags(["strong"])
+        >>> tree.text(deep=True, separator=" ", strip=True)
+        "J ohn Doe" # Text extraction produces an extra space because the strong tag was removed.
+        >>> node.merge_text_nodes()
+        >>> tree.text(deep=True, separator=" ", strip=True)
+        "John Doe"
+        """
+        ...
     def clone(self) -> LexborHTMLParser:
         """Clone the current tree."""
         ...

--- a/selectolax/lexbor.pyx
+++ b/selectolax/lexbor.pyx
@@ -298,6 +298,26 @@ cdef class LexborHTMLParser:
     def css_matches(self, str selector):
         return self.root.css_matches(selector)
 
+    def merge_text_nodes(self):
+        """Iterates over all text nodes and merges all text nodes that are close to each other.
+
+        This is useful for text extraction.
+        Use it when you need to strip HTML tags and merge "dangling" text.
+
+        Examples
+        --------
+
+        >>> tree = LexborHTMLParser("<div><p><strong>J</strong>ohn</p><p>Doe</p></div>")
+        >>> node = tree.css_first('div')
+        >>> tree.unwrap_tags(["strong"])
+        >>> tree.text(deep=True, separator=" ", strip=True)
+        "J ohn Doe" # Text extraction produces an extra space because the strong tag was removed.
+        >>> node.merge_text_nodes()
+        >>> tree.text(deep=True, separator=" ", strip=True)
+        "John Doe"
+        """
+        return self.root.merge_text_nodes()
+
     @staticmethod
     cdef LexborHTMLParser from_document(lxb_html_document_t *document, bytes raw_html):
         obj = <LexborHTMLParser> LexborHTMLParser.__new__(LexborHTMLParser)

--- a/selectolax/lexbor/node.pxi
+++ b/selectolax/lexbor/node.pxi
@@ -512,6 +512,8 @@ cdef class LexborNode:
                     combined = (<bytes>text1[:len1]) + (<bytes>text2[:len2])
                     lxb_dom_node_text_content_set(node, combined, len(combined))
                     lxb_dom_node_remove(node.prev)
+                    lxb_dom_document_destroy_text_noi(node.owner_document, text1)
+                    lxb_dom_document_destroy_text_noi(node.owner_document, text2)
             if node.first_child:
                 LexborNode.new(node, self.parser).merge_text_nodes()
             node = next_node

--- a/selectolax/lexbor/node.pxi
+++ b/selectolax/lexbor/node.pxi
@@ -499,21 +499,19 @@ cdef class LexborNode:
         """
         cdef lxb_dom_node_t *node = self.node.first_child
         cdef lxb_dom_node_t *next_node
-        cdef lxb_char_t *text1
-        cdef lxb_char_t *text2
-        cdef size_t len1, len2
+        cdef lxb_char_t *left_text
+        cdef lxb_char_t *right_text
+        cdef size_t left_length, right_length
 
         while node != NULL:
             next_node = node.next
             if node.type == LXB_DOM_NODE_TYPE_TEXT and node.prev and node.prev.type == LXB_DOM_NODE_TYPE_TEXT:
-                text1 = lxb_dom_node_text_content(node.prev, &len1)
-                text2 = lxb_dom_node_text_content(node, &len2)
-                if text1 and text2:
-                    combined = (<bytes>text1[:len1]) + (<bytes>text2[:len2])
+                left_text = lxb_dom_node_text_content(node.prev, &left_length)
+                right_text = lxb_dom_node_text_content(node, &right_length)
+                if left_text and right_text:
+                    combined = (<bytes>left_text[:left_length]) + (<bytes>right_text[:right_length])
                     lxb_dom_node_text_content_set(node, combined, len(combined))
                     lxb_dom_node_remove(node.prev)
-                    lxb_dom_document_destroy_text_noi(node.owner_document, text1)
-                    lxb_dom_document_destroy_text_noi(node.owner_document, text2)
             if node.first_child:
                 LexborNode.new(node, self.parser).merge_text_nodes()
             node = next_node

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -689,6 +689,16 @@ def test_merge_text_nodes_complex(parser):
     assert root.css_first("section > div").text() == "with more nesting here"
 
 
+@pytest.mark.parametrize("parser", (HTMLParser, LexborHTMLParser))
+def test_merge_text_nodes_three_plus(parser):
+    html = """<div><em>O</em><strong>n</strong><b>e</b> <i>T</i><span>w</span><u>o</u> <small>T</small><big>h</big><mark>r</mark><sub>e</sub><sup>e</sup></div>"""
+    tree = parser(html)
+    tree.unwrap_tags(["em", "strong", "b", "i", "span", "u", "small", "big", "mark", "sub", "sup"])
+    div = tree.css_first("div", strict=True)
+    div.merge_text_nodes()
+    assert div.text() == "One Two Three"
+
+
 @pytest.mark.parametrize(*_PARSERS_PARAMETRIZER)
 def test_css_first_first(parser):
     html = '<h2 class="list-details__item__partial" id="js-partial">(1:1, 0:0, 0:0, 5:3)</h2>'


### PR DESCRIPTION
Simple implementation of `merge_text_nodes` for the `lexbor` backend. This is already implemented for the `modest` backend. Addresses https://github.com/rushter/selectolax/issues/170