### PR TITLE
Changed the `readme` file reference from `README.rst` to `README.md` and update project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [build-system]
 requires = [
     "wheel",
@@ -6,19 +5,17 @@ requires = [
     "setuptools>=62.4",
 ]
 
-
 [project]
 name = 'selectolax'
 version = '0.4.1'
 description = 'Fast HTML5 parser with CSS selectors.'
-readme = 'README.rst'
-requires-python = '>=3.9'
+readme = 'README.md'
+requires-python = '>=3.9,<3.15'
 license = 'MIT'
 authors = [
     { name = 'Artem Golubin', email = 'me@rushter.com' }
 ]
-dependencies = [
-]
+dependencies = []
 
 keywords = [
     "selectolax",
@@ -26,35 +23,52 @@ keywords = [
     "parser",
     "css",
     "fast",
+    "lexbor",
+    "modest",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "Topic :: Text Processing :: Markup :: HTML",
-    "Topic :: Internet",
-    "Topic :: Internet :: WWW/HTTP",
+    "Environment :: Web Environment",
     "Intended Audience :: Developers",
     "Natural Language :: English",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: OS Independent",
+    "Operating System :: Unix",
+    "Programming Language :: Cython",
+    "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Internet",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Text Processing",
+    "Topic :: Text Processing :: Markup",
+    "Topic :: Text Processing :: Markup :: HTML",
+    "Typing :: Typed",
 ]
 
 [project.urls]
+Homepage = "https://github.com/rushter/selectolax"
 Repository = "https://github.com/rushter/selectolax"
 Documentation = "https://selectolax.readthedocs.io/en/latest/parser.html"
 Changelog = "https://github.com/rushter/selectolax/blob/master/CHANGES.md"
-
 
 [tool.cibuildwheel]
 build-frontend = "build"
 build-verbosity = 1
 
-
 [tool.cibuildwheel.linux]
-environment = { LDFLAGS="-Wl,--strip-debug" }
+environment = { LDFLAGS = "-Wl,--strip-debug" }
 
 skip = [
     "*-manylinux_i686",
@@ -64,7 +78,6 @@ skip = [
 ]
 test-skip = "*-macosx_arm64"
 
-
 [project.optional-dependencies]
 cython = [
     "Cython",
@@ -72,4 +85,4 @@ cython = [
 
 [tool.cython-lint]
 max-line-length = 120
-ignore = ['E221','E222',]
+ignore = ['E221', 'E222', ]


### PR DESCRIPTION
This pull request updates the `pyproject.toml` configuration to improve project metadata, clarify Python version support, and enhance discoverability on package indexes. The main changes focus on updating documentation references, tightening Python compatibility, expanding project keywords and classifiers, and adding a homepage URL.

**Project metadata and compatibility updates:**

* Changed the `readme` file reference from `README.rst` to `README.md` for consistency with the repository.
* Updated the supported Python versions to require `>=3.9,<3.15`, clarifying compatibility and excluding unsupported future versions.

**Discoverability and classification improvements:**

* Expanded `keywords` to include `"lexbor"` and `"modest"` for better searchability.
* Significantly extended the list of `classifiers` to more accurately describe the project’s environment, operating systems, supported Python versions (including 3.14), and topics, improving visibility on PyPI.
* Added a `Homepage` URL to the `project.urls` section, making it easier for users to find the main project page.

> [!IMPORTANT]
> Right now, the README.md is not showing on https://pypi.org/project/selectolax/
> This PR will fix this issue.
<img width="1481" height="677" alt="Screenshot 2025-11-16 at 5 25 51" src="https://github.com/user-attachments/assets/27c707ed-1c4c-4d7b-bb8b-28fc51933293" />