### PR TITLE
in Lexbor use python's heap instead of C's heaps

### DIFF
--- a/selectolax/lexbor.pxd
+++ b/selectolax/lexbor.pxd
@@ -1,9 +1,5 @@
 from libc.stdint cimport uint8_t, uint32_t, uintptr_t
 
-
-
-
-
 cdef extern from "lexbor/core/core.h" nogil:
     ctypedef uint32_t lxb_codepoint_t
     ctypedef unsigned char lxb_char_t
@@ -36,15 +32,14 @@ cdef extern from "lexbor/core/core.h" nogil:
     lxb_char_t * lexbor_str_data_noi(lexbor_str_t *str)
 
 cdef extern from "lexbor/core/lexbor.h" nogil:
-    
     ctypedef void *(*lexbor_memory_malloc_f)(size_t size) nogil
     ctypedef void *(*lexbor_memory_realloc_f)(void *dst, size_t size) nogil
     ctypedef void *(*lexbor_memory_calloc_f)(size_t num, size_t size) nogil
-    ctypedef void (*lexbor_memory_free_f)(void *dst) nogil 
+    ctypedef void (*lexbor_memory_free_f)(void *dst) nogil
     lxb_status_t lexbor_memory_setup(
-        lexbor_memory_malloc_f new_malloc, 
-        lexbor_memory_realloc_f new_realloc, 
-        lexbor_memory_calloc_f new_calloc, 
+        lexbor_memory_malloc_f new_malloc,
+        lexbor_memory_realloc_f new_realloc,
+        lexbor_memory_calloc_f new_calloc,
         lexbor_memory_free_f new_free
     )
 

--- a/selectolax/lexbor.pyx
+++ b/selectolax/lexbor.pyx
@@ -1,10 +1,8 @@
 from cpython.bool cimport bool
-from cpython.buffer cimport PyBUF_SIMPLE, PyBuffer_Release, PyObject_GetBuffer
-from cpython.bytes cimport PyBytes_FromStringAndSize
 from cpython.exc cimport PyErr_SetObject
 from cpython.mem cimport (
-    PyMem_RawCalloc, 
-    PyMem_RawFree, 
+    PyMem_RawCalloc,
+    PyMem_RawFree,
     PyMem_RawMalloc,
     PyMem_RawRealloc
 )
@@ -55,7 +53,7 @@ cdef class LexborHTMLParser:
         """
         cdef size_t html_len
         cdef object bytes_html
-        
+
         self._is_fragment = is_fragment
         self._fragment_document = NULL
         self._selector = None
@@ -63,7 +61,6 @@ cdef class LexborHTMLParser:
         bytes_html, html_len = preprocess_input(html)
         self._parse_html(bytes_html, html_len)
         self.raw_html = bytes_html
-
 
     cdef inline lxb_html_document_t* main_document(self) nogil:
         if self._is_fragment:
@@ -763,10 +760,8 @@ cdef class LexborHTMLParser:
 
         return LexborNode.new(dom_node, self)
 
-
-
-# Putting lexbor on python's heap is better than putting it 
-# onto C's Heap, because python's Garbage collector can collect 
+# Putting lexbor on python's heap is better than putting it
+# onto C's Heap, because python's Garbage collector can collect
 # this memory after use and has the bonus of gaining access to
 # mimalloc which python uses under the hood...
 if lexbor_memory_setup(
@@ -775,8 +770,6 @@ if lexbor_memory_setup(
     PyMem_RawCalloc,
     PyMem_RawFree
 ) != LXB_STATUS_OK:
-    # This will almost never happen due to the code in both the windows and posix versions 
+    # This will almost never happen due to the code in both the windows and posix versions
     # but if something were to happen this excecption on import should be triggered...
     raise SelectolaxError("Can't initalize allocators from lexbor_memory_setup(...)")
-
-


### PR DESCRIPTION
While going though the code again I found that lexbor's internal alloc functions could be changed in exchange for python's alloc methods which could improve performance by gaining access to python's garbage memory (allowing possible recycling of old memory) but also allow access mimalloc which python uses under the hood depending on which versions of python are being utilized. I do need to remove something since I was playing around a bit to see if I could get bytearrays, memoryviews to work but I will set that aside for now and put that idea into a future pull request.

