### PR TITLE
docs/examples.rst: Fix code block issue

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -231,6 +231,7 @@ They can be called on any node.
 **Output:**
 
 .. code-block:: text
+
     Inner html:
 
       <div>Hi there</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,6 @@ cython = [
 [tool.cython-lint]
 max-line-length = 120
 ignore = ['E221', 'E222', ]
+
+[tool.setuptools.packages.find]
+include = ["selectolax*"]


### PR DESCRIPTION
Docutils/Sphinx expects a blank line after an indented block (
code, quote, list) before the block ends or a new block begins.